### PR TITLE
getAssetRules method queries optimized

### DIFF
--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -265,6 +265,7 @@ class JAccess
 
 			$result = $temp;
 		}
+
 		// Get the root even if the asset is not found and in recursive mode
 		if (empty($result))
 		{

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -268,7 +268,6 @@ class JAccess
 				$query->where('(name = ' . $db->quote($asset) . ')');
 			}
 
-			$query->group('id');
 			$db->setQuery($query);
 			$result = $db->loadColumn();
 		}


### PR DESCRIPTION
Previous query is consisted with a join operation. In the changed query, first get the lft and rgt values related to the asset id or to the asset name. Then Another query is executed to get the rules.
