### PR TITLE
load method query re wrote decomposing the query in to two

### DIFF
--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -226,10 +226,7 @@ class JCategories
 		$unpublishedCatIds = $db->loadColumn();
 
 		// Right join with c for category
-		$query->select('DISTINCT c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time,
-			c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.language, c.level,
-			c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
-			c.path, c.published, c.rgt, c.title, c.modified_user_id, c.version');
+		$query->select('DISTINCT c.id,c.alias,c.language,c.parent_id,c.path');
 		$case_when = ' CASE WHEN ';
 		$case_when .= $query->charLength('c.alias', '!=', '0');
 		$case_when .= ' THEN ';

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -226,7 +226,7 @@ class JCategories
 		$unpublishedCatIds = $db->loadColumn();
 
 		// Right join with c for category
-		$query->select('DISTINCT c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time,
+		$query->select('c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time,
 				c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.language, c.level,
 				c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
 				c.path, c.published, c.rgt, c.title, c.modified_user_id, c.version');
@@ -284,6 +284,9 @@ class JCategories
 
 			$query->select('COUNT(i.' . $db->quoteName($this->_key) . ') AS numitems');
 		}
+
+		// Group By
+		$query->group('c.id');
 
 		// Get the results
 		$db->setQuery($query);

--- a/libraries/legacy/categories/categories.php
+++ b/libraries/legacy/categories/categories.php
@@ -226,7 +226,10 @@ class JCategories
 		$unpublishedCatIds = $db->loadColumn();
 
 		// Right join with c for category
-		$query->select('DISTINCT c.id,c.alias,c.language,c.parent_id,c.path');
+		$query->select('DISTINCT c.id, c.asset_id, c.access, c.alias, c.checked_out, c.checked_out_time,
+				c.created_time, c.created_user_id, c.description, c.extension, c.hits, c.language, c.level,
+				c.lft, c.metadata, c.metadesc, c.metakey, c.modified_time, c.note, c.params, c.parent_id,
+				c.path, c.published, c.rgt, c.title, c.modified_user_id, c.version');
 		$case_when = ' CASE WHEN ';
 		$case_when .= $query->charLength('c.alias', '!=', '0');
 		$case_when .= ' THEN ';


### PR DESCRIPTION
In this pull request I have changed the _load() method's query by decomposing it in to two. One part is to get the in-published categories and the other is to get the categories. Previous query had this in-published category filtering in the same query using a left join. In the new query the process has been optimized by using the NOT IN operation in order to check the availability of the in-published categories.
