### PR TITLE
Sql optimise killer query2

### DIFF
--- a/components/com_content/models/articles.php
+++ b/components/com_content/models/articles.php
@@ -175,7 +175,7 @@ class ContentModelArticles extends JModelList
 
 		// Create a new query object.
 		$db = $this->getDbo();
-		$db1 = $this->getDbo();
+		$dbBadCat = $this->getDbo();
 		$query = $db->getQuery(true);
 
 		// Query to retrieve the un published categories
@@ -195,8 +195,8 @@ class ContentModelArticles extends JModelList
 			$badCatQuery .= ' AND parent.published != 1 GROUP BY cat.id ';
 		}
 
-		$db1->setQuery($badCatQuery);
-		$badCatIds = $db1->loadColumn();
+		$dbBadCat->setQuery($badCatQuery);
+		$badCatIds = $dbBadCat->loadColumn();
 
 		// Select the required fields from the table.
 		$query->select(

--- a/libraries/joomla/access/access.php
+++ b/libraries/joomla/access/access.php
@@ -265,6 +265,7 @@ class JAccess
 
 			$result = $temp;
 		}
+
 		// Get the root even if the asset is not found and in recursive mode
 		if (empty($result))
 		{


### PR DESCRIPTION
In this commit I have decomposed the getListQuery() method's query in to two cause for the readability and for improve the performance. In the previous query before the change there was a join operation to get the un-published category ids. In this query the former join has been removed and the un-published category ids are being retrieved separately. And then those ids are used with the NOT IN and IN operations in order to improve the performance
